### PR TITLE
ci: create releases with pdf on version tags

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,29 @@
+name: Build poster with typst
+
+on:
+  workflow_call:
+    inputs:
+      is_release:
+        required: true
+        type: boolean
+
+jobs:
+
+  build_typst:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/sdsc-ordes/modos-poster:latest
+
+    steps:
+
+      - uses: actions/checkout@v4
+
+      - name: build
+        run: just build
+
+      - name: upload pdf
+        uses: actions/upload-artifact@v4
+        if: ${{ inputs.is_release }}
+        with:
+          name: poster
+          path: build/modos.pdf

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,11 +20,11 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: build
-        run: typst compile --root . src/modos.typ build/modos.pdf
+        run: typst compile --root . src/modos.typ modos.pdf
 
       - name: upload pdf
         uses: actions/upload-artifact@v4
         if: ${{ inputs.is_release }}
         with:
           name: poster
-          path: build/modos.pdf
+          path: modos.pdf

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,15 +11,16 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
+    # NOTE: use nix container instead
     container:
-      image: ghcr.io/sdsc-ordes/modos-poster:latest
+      image: ghcr.io/typst/typst:latest
 
     steps:
 
       - uses: actions/checkout@v4
 
       - name: build
-        run: just build
+        run: typst compile --root . src/modos.typ build/modos.pdf
 
       - name: upload pdf
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
 
-  build_typst:
+  build:
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/sdsc-ordes/modos-poster:latest

--- a/.github/workflows/main-and-pr.yaml
+++ b/.github/workflows/main-and-pr.yaml
@@ -1,0 +1,16 @@
+name: Main and PR pipeline
+
+on:
+  push:
+    branches:
+      - main
+
+  pull_request:
+    branches:
+      - main
+
+  jobs:
+    normal:
+      uses: ./.github/workflows/build.yaml
+      with:
+        is_release: false

--- a/.github/workflows/main-and-pr.yaml
+++ b/.github/workflows/main-and-pr.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_call:
 
   pull_request:
     branches:

--- a/.github/workflows/main-and-pr.yaml
+++ b/.github/workflows/main-and-pr.yaml
@@ -10,8 +10,8 @@ on:
     branches:
       - main
 
-  jobs:
-    normal:
-      uses: ./.github/workflows/build.yaml
-      with:
-        is_release: false
+jobs:
+  normal:
+    uses: ./.github/workflows/build.yaml
+    with:
+      is_release: false

--- a/.github/workflows/main-and-pr.yml
+++ b/.github/workflows/main-and-pr.yml
@@ -12,6 +12,6 @@ on:
 
 jobs:
   normal:
-    uses: ./.github/workflows/build.yaml
+    uses: ./.github/workflows/build.yml
     with:
       is_release: false

--- a/.github/workflows/main-and-pr.yml
+++ b/.github/workflows/main-and-pr.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+
   workflow_call:
 
   pull_request:
@@ -11,7 +12,7 @@ on:
       - main
 
 jobs:
-  normal:
+  build:
     uses: ./.github/workflows/build.yml
     with:
       is_release: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,33 @@
+name: Include poster in release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+
+  build_typst:
+    uses: ./.github/workflows/build.yml
+    with:
+      is_release: true
+
+  make_release:
+    needs:
+      build_typst
+
+    steps:
+
+      - name: get pdf
+        uses: actions/download-artifact@v4.1.8
+        with:
+          name: poster
+          path: build/modos.pdf
+
+      - uses: actions/checkout@v4
+
+      - name: create release
+        uses: actions/action-gh-release@v2
+        with:
+          files: build/modos.pdf
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,12 +23,12 @@ jobs:
         uses: actions/download-artifact@v4.1.8
         with:
           name: poster
-          path: build/modos.pdf
+          path: modos.pdf
 
       - uses: actions/checkout@v4
 
       - name: create release
         uses: softprops/action-gh-release@v2
         with:
-          files: build/modos.pdf
+          files: modos.pdf
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,10 +25,10 @@ jobs:
         uses: actions/download-artifact@v4.1.8
         with:
           name: poster
-          path: modos.pdf
+          path: build/
 
       - name: create release
         uses: softprops/action-gh-release@v2
         with:
-          files: modos.pdf
+          files: build/modos.pdf
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,13 +19,13 @@ jobs:
 
     steps:
 
+      - uses: actions/checkout@v4
+
       - name: get pdf
         uses: actions/download-artifact@v4.1.8
         with:
           name: poster
           path: modos.pdf
-
-      - uses: actions/checkout@v4
 
       - name: create release
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: create release
-        uses: actions/action-gh-release@v2
+        uses: softprops/action-gh-release@v2
         with:
           files: build/modos.pdf
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ jobs:
       is_release: true
 
   make_release:
+    runs-on: ubuntu-latest
     needs:
       build_typst
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
 # modos-poster
+
+[![DOI](https://zenodo.org/badge/824321703.svg)](https://zenodo.org/doi/10.5281/zenodo.13312849)
+
+
 Poster presentation of modos (multi-omics digital object system).
 
 ## Setup

--- a/justfile
+++ b/justfile
@@ -3,6 +3,8 @@ set shell := ["bash", "-cue"]
 root := justfile_directory()
 src := "./src/modos.typ"
 pdf := "./build/modos.pdf"
+image := "ghcr.io/sdsc-ordes/modos-poster"
+tag := "latest"
 
 
 ## Generate poster
@@ -35,12 +37,16 @@ develop-docker:
     -it \
     -w "/build/work" \
     --mount type=bind,source="$(pwd)",target=/build/work \
-    "ghcr.io/sdsc-ordes/modos-poster:latest"
+    {{image}}:{{tag}}
 
 
 ## Maintenance
 
 # builds oci image with nix and load into docker
-build-docker:
+docker-build:
   nix build -L "./tools/nix#image" --out-link "build/image" \
   && docker load < "build/image"
+
+# build and push image
+docker-push: docker-build
+  docker push {{image}}:{{tag}}

--- a/tools/nix/flake.nix
+++ b/tools/nix/flake.nix
@@ -27,17 +27,12 @@
         shellHook = "unset TMPDIR";
       };
       packages = {
-        image = pkgs.dockerTools.buildImage {
+        image = pkgs.dockerTools.buildLayeredImage {
           name = "ghcr.io/sdsc-ordes/modos-poster";
           tag = "latest";
-          copyToRoot = pkgs.buildEnv {
-            name = "image-env";
-            paths = nativeBuildInputs;
-            pathsToLink = [ "/bin" ];
-          };
+          contents = nativeBuildInputs;
           config = {
-            Env = [ "PATH=/bin:$PATH" ];
-            Cmd = [ "${pkgs.bash}/bin/bash" ];
+            Cmd = [ "/bin/bash" ];
           };
         };
       };

--- a/tools/nix/flake.nix
+++ b/tools/nix/flake.nix
@@ -10,7 +10,16 @@
       pkgs = import nixpkgs {
         inherit system;
       };
-      nativeBuildInputs = with pkgs; [ just typst ];
+      nativeBuildInputs = with pkgs; [
+        just
+        typst
+        coreutils
+        bash
+        zsh
+        curl
+        git
+        jq
+      ];
     in
     {
       devShells.default = pkgs.mkShell {

--- a/tools/nix/flake.nix
+++ b/tools/nix/flake.nix
@@ -11,26 +11,33 @@
         inherit system;
       };
       nativeBuildInputs = with pkgs; [
-        just
-        typst
-        coreutils
         bash
-        zsh
+        coreutils
         curl
+        findutils
         git
         jq
+        just
+        typst
       ];
     in
     {
       devShells.default = pkgs.mkShell {
         inherit nativeBuildInputs;
+        shellHook = "unset TMPDIR";
       };
       packages = {
-        image = pkgs.dockerTools.buildNixShellImage {
+        image = pkgs.dockerTools.buildImage {
           name = "ghcr.io/sdsc-ordes/modos-poster";
           tag = "latest";
-          drv = pkgs.mkShell {
-            inherit nativeBuildInputs;
+          copyToRoot = pkgs.buildEnv {
+            name = "image-env";
+            paths = nativeBuildInputs;
+            pathsToLink = [ "/bin" ];
+          };
+          config = {
+            Env = [ "PATH=/bin:$PATH" ];
+            Cmd = [ "${pkgs.bash}/bin/bash" ];
           };
         };
       };


### PR DESCRIPTION
This adds CI to automatically create a release with the compiled PDF included whenever a tag named `v*` is pushed. This should automatically trigger archiving on zenodo.